### PR TITLE
Allow a range of Numpy versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ atomicwrites==1.1.5
 attrs==18.1.0
 funcsigs==1.0.2
 more-itertools==4.3.0
-numpy==1.15.0
+numpy>=1.15.0
 pathlib2==2.3.2
 pluggy==0.7.1
 py==1.5.4

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
   url = 'https://github.com/redft/hexy',   
   download_url = 'https://github.com/RedFT/Hexy/archive/1.4.tar.gz',    
   keywords = ['hexy', 'coordinate', 'hexagon', 'hexagonal'],
-  install_requires = ["numpy == 1.15.0"],
+  install_requires = ["numpy >= 1.15.0"],
   extras_require ={            
       'examples': [
         "atomicwrites (==1.1.5)",


### PR DESCRIPTION
Otherwise this package will not install if there is a newer version
of numpy already installed on the system.  Or it will install by
downgrading the system's version of numpy.