### PR TITLE
removed requirements.txt. Travis should be able to pull test dependen…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: python
 python:
-    - "2.7"
+    - "3"
+
 install:
-    - pip install -r requirements.txt
+    - pip install -e .[tests]
 
 script:
     - python -m pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-    - "3"
+    - "3.6"
 
 install:
     - pip install -e .[tests]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,0 @@
-atomicwrites==1.1.5
-attrs==18.1.0
-funcsigs==1.0.2
-more-itertools==4.3.0
-numpy>=1.15.0
-pluggy==0.7.1
-py==1.5.4
-pytest==3.7.0
-six==1.11.0


### PR DESCRIPTION
removed `requirements.txt` file. Travis CI should be able to pull test dependencies from pypi. Now we only need to keep track of dependencies in one place (`setup.py`) instead of two.