### PR TITLE
Add function to compute a radius necessary to fit a number of hexes

### DIFF
--- a/hexy/hexy.py
+++ b/hexy/hexy.py
@@ -18,6 +18,34 @@ E = np.array((1, -1, 0))
 ALL_DIRECTIONS = np.array([NW, NE, E, SE, SW, W, ])
 
 
+def radius_from_hexes(hexes):
+    """
+    Computes the radius necessary to fit a set amount of hexes in the area generated
+    by :func:`~hexy.get_spiral`.
+
+    The formula documented on https://www.redblobgames.com/grids/hexagons/#rings-spiral,
+    to find the amount of hexes for a given radius is::
+
+        1 + 3 * radius * (radius+1) = s
+
+    It is a quadratic equation that can be resolved to::
+
+        radius = (2 * ((-s + 1) / 3)) / (-1 - sqrt(1^2 - 4 * ((-s + 1) / 3)))
+
+    :param hexes: The amount of hexes to fit on the board.
+    :type hexes: int
+    :return: The radius of a spiral as an integer.
+    :rtype: int
+    """
+    if type(hexes) != int:
+        raise TypeError(
+            "radius_from_hexes() argument must be an integer, not {}".format(
+                type(hexes)
+            )
+        )
+    return np.ceil(np.sqrt((hexes - 1) / 3 + 1 / 4) - 1 / 2)
+
+
 def get_cube_distance(hex_start, hex_end):
     """
     Computes the smallest number of hexes between hex_start and hex_end, on the hex lattice.

--- a/test/test_conversions.py
+++ b/test/test_conversions.py
@@ -7,6 +7,13 @@ radius = 10
 coords = hx.get_spiral(np.array((0, 0, 0)), 1, 10)
 
 
+def test_hexes_amount_to_radius_conversion():
+    hexes = 1 + 3 * radius * (radius + 1)
+    found_radius = hx.radius_from_hexes(hexes)
+
+    assert found_radius == radius
+
+
 def test_axial_to_cube_conversion():
     axial_coords = hx.cube_to_axial(coords)
     cube_coords = hx.axial_to_cube(axial_coords)


### PR DESCRIPTION
Sometimes we start with a number of tiles and the necessary radius as an unknown. The new function `radius_from_hexes` will serve as a helper to resolve that unknown.

So far I've looked, I haven't found a similar function in the existing codebase. I may be wrong though.